### PR TITLE
Update animation loader to fetch frames from remote URL

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,9 +4,9 @@ class AnimationLoader {
         this.currentFrame = 0;
         this.isDragging = false;
         this.frames = [];
-        // Use local images rather than remote storage so the demo works
-        // offline or in restricted environments.
-        this.baseUrl = 'sec/Comp_';
+        // Load frames from the remote storage bucket
+        // where the sequence is hosted.
+        this.baseUrl = 'https://storage.yandexcloud.net/presentation1/Comp_';
         this.fileExtension = '.png';
         // Reduce minimum load time to avoid long delays
         this.minLoadTime = 1000;


### PR DESCRIPTION
## Summary
- load image sequence from remote storage instead of local folder

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f452f5d38832f831753775445a5a0