### PR TITLE
Add option to start animation from specific page

### DIFF
--- a/page23.html
+++ b/page23.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scroll Animation</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="animation-container">
+        <div id="loading-container">
+            <div class="spinner">
+                <div class="circle circle1"></div>
+                <div class="circle circle2"></div>
+                <div class="circle circle3"></div>
+            </div>
+        </div>
+
+        <div id="intro-text">
+            <div class="line line-1">РАЗРАБОТКА</div>
+            <div class="line line-2">САЙТА</div>
+            <div class="line line-3">ДИЗАЙН-СТУДИИ</div>
+        </div>
+
+        <div id="author-contact">@al_al_ni</div>
+
+        <div id="phase-title">УЧАСТНИКИ ПРОЦЕССА</div>
+        <div id="plan-title">ПЛАН РЕАЛИЗАЦИИ</div>
+
+        <img id="frame" style="display: none;">
+        <div id="pagination"></div>
+        <div id="scrollbar">
+            <div id="scrollbar-thumb"></div>
+        </div>
+    </div>
+    <script>
+        window.animationLoaderOptions = {
+            startFrame: 44,
+            pages: [
+                { label: '2', frame: 44 },
+                { label: '3', frame: 88 }
+            ]
+        };
+    </script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,8 @@
 class AnimationLoader {
-    constructor() {
+    constructor(options = {}) {
         this.totalFrames = 132; // увеличено для поддержки третьей страницы
-        this.currentFrame = 0;
+        this.startFrame = options.startFrame || 0;
+        this.currentFrame = this.startFrame;
         this.isDragging = false;
         this.animating = false;
         this.frames = [];
@@ -12,7 +13,7 @@ class AnimationLoader {
         // Reduce minimum load time to avoid long delays
         this.minLoadTime = 1000;
 
-        this.pages = [
+        this.pages = options.pages || [
             { label: '1', frame: 0 },
             { label: '2', frame: 44 },
             { label: '3', frame: 88 }
@@ -56,19 +57,21 @@ class AnimationLoader {
     async loadFirstFrame() {
         return new Promise((resolve) => {
             const img = new Image();
+            const start = this.startFrame;
             img.onload = async () => {
                 try {
                     await img.decode();
                 } catch {}
-                this.frames[0] = img;
+                this.frames[start] = img;
+                this.currentFrame = start;
                 this.elements.frame.src = img.src;
                 resolve();
             };
             img.onerror = () => {
                 console.error('Error loading first frame');
-                this.generateFallbackFrame(0).then(resolve);
+                this.generateFallbackFrame(start).then(resolve);
             };
-            img.src = this.getFramePath(0);
+            img.src = this.getFramePath(start);
         });
     }
 
@@ -279,6 +282,7 @@ class AnimationLoader {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const loader = new AnimationLoader();
+    const options = window.animationLoaderOptions || {};
+    const loader = new AnimationLoader(options);
     loader.init();
 });


### PR DESCRIPTION
## Summary
- add optional parameters to `AnimationLoader` to control start frame and pages
- expose global `window.animationLoaderOptions` to pass options from HTML
- add new page `page23.html` that starts on the second slide and contains only pages 2–3

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687fd1fafb54832f83ca0f9dce541ba0