### PR TITLE
Add resume as third block

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,10 @@
         <div id="phase-title">УЧАСТНИКИ ПРОЦЕССА</div>
         <div id="plan-title">ПЛАН РЕАЛИЗАЦИИ</div>
 
+        <div id="resume-wrapper">
+            <iframe id="resume-iframe" src="resume.html"></iframe>
+        </div>
+
         <img id="frame" style="display: none;">
         <div id="pagination"></div>
         <div id="scrollbar">

--- a/script.js
+++ b/script.js
@@ -27,7 +27,8 @@ class AnimationLoader {
             authorContact: document.getElementById('author-contact'),
             phaseTitle: document.getElementById('phase-title'),
             planTitle: document.getElementById('plan-title'),
-            pagination: document.getElementById('pagination')
+            pagination: document.getElementById('pagination'),
+            resume: document.getElementById('resume-wrapper')
         };
     }
 
@@ -162,6 +163,16 @@ class AnimationLoader {
                 const fadeInEnd = 95;
                 const progress = Math.min(1, Math.max(0, (index - fadeInStart) / (fadeInEnd - fadeInStart)));
                 planTitle.style.opacity = progress;
+            }
+
+            // Плавное появление секции резюме
+            const resume = this.elements.resume;
+            if (resume) {
+                const fadeInStart = 96;
+                const fadeInEnd = 100;
+                const progress = Math.min(1, Math.max(0, (index - fadeInStart) / (fadeInEnd - fadeInStart)));
+                resume.style.opacity = progress;
+                resume.style.pointerEvents = progress > 0 ? 'auto' : 'none';
             }
         }
     }

--- a/styles.css
+++ b/styles.css
@@ -213,3 +213,18 @@ body {
     box-shadow: 0 0 0 2px #fff;
 }
 
+#resume-wrapper {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    transition: opacity 0.5s ease;
+    pointer-events: none;
+    overflow-y: auto;
+}
+
+#resume-iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+


### PR DESCRIPTION
## Summary
- embed resume page within index.html
- add styles and JS logic to fade in the resume block

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68807778cb18832fb336ab224ba455bd