### PR TITLE
Fix page navigation when returning from third page

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,6 +22,7 @@ class AnimationLoader {
         ];
 
         this.elements = {
+            container: document.getElementById('animation-container'),
             frame: document.getElementById('frame'),
             loading: document.getElementById('loading-container'),
             scrollbar: document.getElementById('scrollbar'),
@@ -213,7 +214,14 @@ class AnimationLoader {
                     btn.classList.add('active');
                 });
             } else {
-                btn.addEventListener('click', () => this.animateToFrame(page.frame));
+                btn.addEventListener('click', () => {
+                    this.animateToFrame(page.frame);
+                    if (this.elements.container) {
+                        this.elements.container.scrollIntoView({ behavior: 'smooth' });
+                    } else {
+                        window.scrollTo({ top: 0, behavior: 'smooth' });
+                    }
+                });
             }
             this.elements.pagination.appendChild(btn);
             return btn;


### PR DESCRIPTION
## Summary
- ensure scroll position resets when navigating back to the animation
- keep a reference to the animation container for scrolling

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6880b8aeae50832faa7f6dfa646219ec