### PR TITLE
Fix pagination buttons after scrolling

### DIFF
--- a/script.js
+++ b/script.js
@@ -29,7 +29,8 @@ class AnimationLoader {
             introText: document.getElementById('intro-text'),
             authorContact: document.getElementById('author-contact'),
             phaseTitle: document.getElementById('phase-title'),
-            pagination: document.getElementById('pagination')
+            pagination: document.getElementById('pagination'),
+            animationContainer: document.getElementById('animation-container')
         };
     }
 
@@ -213,7 +214,14 @@ class AnimationLoader {
                     btn.classList.add('active');
                 });
             } else {
-                btn.addEventListener('click', () => this.animateToFrame(page.frame));
+                btn.addEventListener('click', () => {
+                    if (this.elements.animationContainer) {
+                        this.elements.animationContainer.scrollIntoView({ behavior: 'smooth' });
+                    } else {
+                        window.scrollTo({ top: 0, behavior: 'smooth' });
+                    }
+                    this.animateToFrame(page.frame);
+                });
             }
             this.elements.pagination.appendChild(btn);
             return btn;


### PR DESCRIPTION
## Summary
- keep pagination visible after navigating to the implementation plan
- scroll back to the animation container when changing frames

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6880ba15d9dc832fa6723cda2a8bacf9