### PR TITLE
Fix pagination scrolling for animation section

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,6 +22,7 @@ class AnimationLoader {
         ];
 
         this.elements = {
+            container: document.getElementById('animation-container'),
             frame: document.getElementById('frame'),
             loading: document.getElementById('loading-container'),
             scrollbar: document.getElementById('scrollbar'),
@@ -213,7 +214,10 @@ class AnimationLoader {
                     btn.classList.add('active');
                 });
             } else {
-                btn.addEventListener('click', () => this.animateToFrame(page.frame));
+                btn.addEventListener('click', () => {
+                    this.elements.container.scrollIntoView({ behavior: 'smooth' });
+                    this.animateToFrame(page.frame);
+                });
             }
             this.elements.pagination.appendChild(btn);
             return btn;


### PR DESCRIPTION
## Summary
- restore pagination behavior after navigating to post-animation block
- when clicking buttons tied to frames, ensure the page scrolls back to the animation container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880bf2117dc832f8469d4daeec0246e