### PR TITLE
Add audience slide and update animation frames

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
 
         <div id="phase-title">УЧАСТНИКИ ПРОЦЕССА</div>
         <div id="plan-title">ПЛАН РЕАЛИЗАЦИИ</div>
+        <div id="audience-title">ЦЕЛЕВАЯ АУДИТОРИЯ</div>
 
         <img id="frame" style="display: none;">
         <div id="pagination"></div>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,8 @@
 class AnimationLoader {
     constructor() {
         // Количество кадров в секвенции
-        // обновлено на 61 в соответствии с текущими данными
-        this.totalFrames = 61;
+        // обновлено на 226 в соответствии с текущими данными
+        this.totalFrames = 226;
         this.currentFrame = 0;
         this.isDragging = false;
         this.animating = false;
@@ -10,16 +10,17 @@ class AnimationLoader {
         // Load frames from the remote storage bucket
         // where the sequence is hosted.
         this.baseUrl = 'https://storage.yandexcloud.net/presentation1/Comp_';
-        this.fileExtension = '.png';
+        this.fileExtension = '.webp';
         // Reduce minimum load time to avoid long delays
         this.minLoadTime = 1000;
 
         // Кадры начала каждой страницы
         this.pages = [
             { label: '1', frame: 0 },
-            { label: '2', frame: 44 },
+            { label: '2', frame: 60 },
+            { label: '3', frame: 92 },
             // последняя страница ведёт на заключительный кадр
-            { label: '3', frame: 60 }
+            { label: '4', frame: 225 }
         ];
 
         this.elements = {
@@ -31,6 +32,7 @@ class AnimationLoader {
             authorContact: document.getElementById('author-contact'),
             phaseTitle: document.getElementById('phase-title'),
             planTitle: document.getElementById('plan-title'),
+            audienceTitle: document.getElementById('audience-title'),
             pagination: document.getElementById('pagination')
         };
     }
@@ -163,8 +165,19 @@ class AnimationLoader {
             if (planTitle) {
                 const fadeInStart = 45;
                 const fadeInEnd = 48;
+                const fadeOutStart = 93;
+                const fadeOutEnd = 108;
+                const fadeInProgress = Math.min(1, Math.max(0, (index - fadeInStart) / (fadeInEnd - fadeInStart)));
+                const fadeOutProgress = Math.min(1, Math.max(0, (index - fadeOutStart) / (fadeOutEnd - fadeOutStart)));
+                planTitle.style.opacity = fadeInProgress * (1 - fadeOutProgress);
+            }
+
+            const audienceTitle = this.elements.audienceTitle;
+            if (audienceTitle) {
+                const fadeInStart = 93;
+                const fadeInEnd = 108;
                 const progress = Math.min(1, Math.max(0, (index - fadeInStart) / (fadeInEnd - fadeInStart)));
-                planTitle.style.opacity = progress;
+                audienceTitle.style.opacity = progress;
             }
         }
     }

--- a/styles.css
+++ b/styles.css
@@ -172,6 +172,21 @@ body {
     text-transform: uppercase;
 }
 
+#audience-title {
+    position: absolute;
+    top: calc(160 / 2160 * 100vh);
+    left: calc(200 / 3840 * 100vw);
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 600;
+    font-size: calc(144 / 2160 * 100vh);
+    color: white;
+    z-index: 10;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    text-transform: uppercase;
+}
+
 #pagination {
     position: absolute;
     top: calc(100 / 2160 * 100vh);


### PR DESCRIPTION
## Summary
- support 226-frame sequence and load `.webp` images
- add fourth pagination button at frame 225
- fade out `plan-title` between frames 93–108 and fade in new `audience-title`
- style and display the new audience title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884725b3544832f84c65311b98266e2