### PR TITLE
Refine numeric page button behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -184,9 +184,17 @@ class AnimationLoader {
 
     animateToFrame(target) {
         if (this.animating) return;
+
+        // If navigating backwards or to the same frame, jump directly
+        if (target <= this.currentFrame) {
+            this.showFrame(target);
+            return;
+        }
+
         this.animating = true;
-        const step = target > this.currentFrame ? 1 : -1;
-        const frameDuration = 1000 / 30; // 30 fps
+        const step = 1; // only move forward
+        // Slow down forward animation by 1.5x (≈20fps)
+        const frameDuration = (1000 / 30) * 1.5;
         const animate = () => {
             if (this.currentFrame === target) {
                 this.animating = false;


### PR DESCRIPTION
## Summary
- slow down page transition animation when moving forward
- skip reverse animation when selecting an earlier page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688482c29c20832fa432e4c10c0353fe