### PR TITLE
Add basic Telegram bot setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+BOT_TOKEN=your_bot_token_here

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,18 @@
+from telegram.ext import Application, CommandHandler
+
+async def start(update, context):
+    await update.message.reply_text("Привет! Я помогу тебе подобрать стиль интерьера.")
+
+async def main():
+    from dotenv import load_dotenv
+    import os, asyncio
+    load_dotenv()
+    token = os.getenv("BOT_TOKEN")
+    app = Application.builder().token(token).build()
+    app.add_handler(CommandHandler("start", start))
+    print("✅ Бот запущен")
+    await app.run_polling()
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add .env with BOT_TOKEN variable
- include basic Telegram bot script responding to /start

## Testing
- `pip install python-telegram-bot python-dotenv` *(fails: Could not find a version that satisfies the requirement python-telegram-bot)*
- `python3 bot.py` *(fails: ModuleNotFoundError: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_68925f76f93c832f877296d1b63f53f3