### PR TITLE
Adjust frame timings for titles and prototype styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,9 +21,9 @@ class AnimationLoader {
             { label: '3', frame: 92 },
             { label: '4', frame: 225 },
             { label: '5', frame: 268 },
-            { label: '6', frame: 330 },
-            { label: '7', frame: 447 },
-            { label: '8', frame: 834 }
+            { label: '6', frame: 327 },
+            { label: '7', frame: 435 },
+            { label: '8', frame: 840 }
         ];
 
         this.elements = {
@@ -198,10 +198,10 @@ class AnimationLoader {
 
             const architectureTitle = this.elements.architectureTitle;
             if (architectureTitle) {
-                const fadeInStart = 330;
-                const fadeInEnd = 345;
-                const fadeOutStart = 447;
-                const fadeOutEnd = 462;
+                const fadeInStart = 327;
+                const fadeInEnd = 342;
+                const fadeOutStart = 435;
+                const fadeOutEnd = 450;
                 const fadeInProgress = Math.min(1, Math.max(0, (index - fadeInStart) / (fadeInEnd - fadeInStart)));
                 const fadeOutProgress = Math.min(1, Math.max(0, (index - fadeOutStart) / (fadeOutEnd - fadeOutStart)));
                 architectureTitle.style.opacity = fadeInProgress * (1 - fadeOutProgress);
@@ -209,10 +209,10 @@ class AnimationLoader {
 
             const moodboardTitle = this.elements.moodboardTitle;
             if (moodboardTitle) {
-                const fadeInStart = 447;
-                const fadeInEnd = 462;
-                const fadeOutStart = 834;
-                const fadeOutEnd = 849;
+                const fadeInStart = 435;
+                const fadeInEnd = 450;
+                const fadeOutStart = 840;
+                const fadeOutEnd = 855;
                 const fadeInProgress = Math.min(1, Math.max(0, (index - fadeInStart) / (fadeInEnd - fadeInStart)));
                 const fadeOutProgress = Math.min(1, Math.max(0, (index - fadeOutStart) / (fadeOutEnd - fadeOutStart)));
                 moodboardTitle.style.opacity = fadeInProgress * (1 - fadeOutProgress);
@@ -220,8 +220,8 @@ class AnimationLoader {
 
             const prototypeTitle = this.elements.prototypeTitle;
             if (prototypeTitle) {
-                const fadeInStart = 834;
-                const fadeInEnd = 849;
+                const fadeInStart = 840;
+                const fadeInEnd = 855;
                 const progress = Math.min(1, Math.max(0, (index - fadeInStart) / (fadeInEnd - fadeInStart)));
                 prototypeTitle.style.opacity = progress;
             }

--- a/styles.css
+++ b/styles.css
@@ -162,6 +162,10 @@ body {
     text-transform: uppercase;
 }
 
+#prototype-title {
+    color: #000;
+}
+
 #pagination {
     position: absolute;
     top: calc(100 / 2160 * 100vh);


### PR DESCRIPTION
## Summary
- Align Architecture, Moodboard, and Prototype sections with new frame start positions
- Make Prototype title text black

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e4ca8d68832f9342371f90077a51