### PR TITLE
Add step navigation buttons to animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,11 @@
         <div id="prototype-title">ПРОТОТИП</div>
 
         <img id="frame" style="display: none;">
-        <div id="pagination"></div>
+        <div id="pagination-controls">
+            <button id="step-prev" class="step-button">&#9664;</button>
+            <div id="pagination"></div>
+            <button id="step-next" class="step-button">&#9654;</button>
+        </div>
         <div id="scrollbar">
             <div id="scrollbar-thumb"></div>
         </div>

--- a/script.js
+++ b/script.js
@@ -26,6 +26,10 @@ class AnimationLoader {
             { label: '8', frame: 840 }
         ];
 
+        // Шаги для поэтапной навигации
+        this.steps = [0, 38, 60, 92, 225, 268, 327, 435, 840];
+        this.currentStepIndex = 0;
+
         this.elements = {
             frame: document.getElementById('frame'),
             loading: document.getElementById('loading-container'),
@@ -39,7 +43,9 @@ class AnimationLoader {
             architectureTitle: document.getElementById('architecture-title'),
             moodboardTitle: document.getElementById('moodboard-title'),
             prototypeTitle: document.getElementById('prototype-title'),
-            pagination: document.getElementById('pagination')
+            pagination: document.getElementById('pagination'),
+            stepPrev: document.getElementById('step-prev'),
+            stepNext: document.getElementById('step-next')
         };
     }
 
@@ -49,6 +55,7 @@ class AnimationLoader {
         this.setupEventListeners();
         this.buildPagination();
         await this.loadFirstFrame();
+        this.showFrame(0);
         this.preloadOtherFrames();
 
         const elapsed = Date.now() - startTime;
@@ -136,6 +143,8 @@ class AnimationLoader {
             }
             this.updateScrollbar();
             this.updatePagination();
+            this.updateStepIndex();
+            this.updateStepButtons();
 
             const body = document.body;
             if (index >= 683) {
@@ -316,6 +325,28 @@ class AnimationLoader {
         });
     }
 
+    updateStepIndex() {
+        for (let i = 0; i < this.steps.length; i++) {
+            if (this.currentFrame >= this.steps[i]) {
+                this.currentStepIndex = i;
+            }
+        }
+    }
+
+    updateStepButtons() {
+        if (!this.elements.stepPrev || !this.elements.stepNext) return;
+        this.elements.stepPrev.disabled = this.currentStepIndex === 0;
+        this.elements.stepNext.disabled = this.currentStepIndex === this.steps.length - 1;
+    }
+
+    navigateStep(direction) {
+        const newIndex = this.currentStepIndex + direction;
+        if (newIndex < 0 || newIndex >= this.steps.length) return;
+        this.currentStepIndex = newIndex;
+        this.animateToFrame(this.steps[this.currentStepIndex]);
+        this.updateStepButtons();
+    }
+
     setupEventListeners() {
         let wheelDelta = 0;
         let ticking = false;
@@ -353,6 +384,11 @@ class AnimationLoader {
             const frame = Math.floor(percent * (this.totalFrames - 1));
             this.showFrame(frame);
         });
+
+        if (this.elements.stepPrev && this.elements.stepNext) {
+            this.elements.stepPrev.addEventListener('click', () => this.navigateStep(-1));
+            this.elements.stepNext.addEventListener('click', () => this.navigateStep(1));
+        }
     }
 
     handleDrag(e) {

--- a/styles.css
+++ b/styles.css
@@ -166,17 +166,24 @@ body {
     color: #000;
 }
 
-#pagination {
+#pagination-controls {
     position: absolute;
     top: calc(100 / 2160 * 100vh);
     right: calc(200 / 3840 * 100vw);
     display: flex;
+    align-items: center;
     gap: 0.5em;
     z-index: 10;
     pointer-events: auto;
 }
 
-.page-button {
+#pagination {
+    display: flex;
+    gap: 0.5em;
+}
+
+.page-button,
+.step-button {
     font-family: 'Montserrat', sans-serif;
     font-weight: 600;
     font-size: calc(60 / 2160 * 100vh);
@@ -189,14 +196,22 @@ body {
     transition: background-color 0.3s ease, transform 0.2s ease;
 }
 
-.page-button:hover {
+.page-button:hover,
+.step-button:hover {
     background-color: #FF9500;
     color: #11192C;
     transform: scale(1.05);
 }
 
-.page-button:active {
+.page-button:active,
+.step-button:active {
     transform: scale(0.95);
+}
+
+.step-button:disabled {
+    opacity: 0.5;
+    cursor: default;
+    transform: none;
 }
 
 .page-button.active {


### PR DESCRIPTION
## Summary
- Add left/right step navigation controls around pagination
- Style new navigation buttons and container
- Implement step-based frame navigation separate from page navigation

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aeadb003fc832fb0201514c169d690