### PR TITLE
Link final step to last frame

### DIFF
--- a/script.js
+++ b/script.js
@@ -42,7 +42,7 @@ class AnimationLoader {
             257, // Шаг 13 - comp_00257
             330, // Шаг 14 - comp_00330
             344, // Шаг 15 - comp_00344
-            355  // Шаг 16 - comp_00355
+            this.totalFrames - 1 // Шаг 16 - последний кадр
         ];
         this.currentStepIndex = 0;
 


### PR DESCRIPTION
## Summary
- Link the final step in the navigation sequence to the animation's last frame

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af191a2814832f83c02132a63be5a8