### PR TITLE
fix: improve sequence loading

### DIFF
--- a/script.js
+++ b/script.js
@@ -91,6 +91,8 @@ class AnimationLoader {
     async loadFirstFrame() {
         return new Promise((resolve) => {
             const img = new Image();
+            // allow loading from external buckets
+            img.crossOrigin = 'anonymous';
             img.onload = async () => {
                 try {
                     await img.decode();
@@ -109,19 +111,19 @@ class AnimationLoader {
 
     preloadOtherFrames() {
         for (let i = 1; i < this.totalFrames; i++) {
-            setTimeout(() => {
-                const img = new Image();
-                img.onload = async () => {
-                    try {
-                        await img.decode();
-                    } catch {}
-                    this.frames[i] = img;
-                };
-                img.onerror = () => {
-                    this.generateFallbackFrame(i);
-                };
-                img.src = this.getFramePath(i);
-            }, i * 100);
+            const img = new Image();
+            // allow loading from external buckets
+            img.crossOrigin = 'anonymous';
+            img.onload = async () => {
+                try {
+                    await img.decode();
+                } catch {}
+                this.frames[i] = img;
+            };
+            img.onerror = () => {
+                this.generateFallbackFrame(i);
+            };
+            img.src = this.getFramePath(i);
         }
     }
 
@@ -279,6 +281,8 @@ class AnimationLoader {
 
     loadFrame(index) {
         const img = new Image();
+        // allow loading from external buckets
+        img.crossOrigin = 'anonymous';
         img.onload = () => {
             this.frames[index] = img;
             this.elements.frame.src = img.src;


### PR DESCRIPTION
## Summary
- allow cross-origin loading for animation frames
- remove slow sequential preload delay to improve frame loading

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af23fd9ef4832f955ac55a2a7d3a2e