### PR TITLE
fix animation loader base URL

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,7 +9,7 @@ class AnimationLoader {
         this.frames = [];
         // Load frames from the remote storage bucket
         // where the sequence is hosted.
-        this.baseUrl = 'https://storage.yandexcloud.net/presentation1/comp_';
+        this.baseUrl = 'https://storage.yandexcloud.net/presentation1/Comp_';
         this.fileExtension = '.webp';
         // Reduce minimum load time to avoid long delays
         this.minLoadTime = 1000;


### PR DESCRIPTION
## Summary
- point animation loader to correct capitalized Comp_ path

## Testing
- `curl -I https://storage.yandexcloud.net/presentation1/Comp_00000.webp` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af32e48564832f8681663a6a0e471a